### PR TITLE
Simplify page positioning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,9 +8,9 @@
   ],
   "main": "swipe-pages.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^0.4.0"
+    "polymer": "Polymer/polymer#0.5.4"
   },
   "devDependencies": {
-    "polymer-test-tools": "Polymer/polymer-test-tools#^0.4.0"
+    "polymer-test-tools": "Polymer/polymer-test-tools#0.5.4"
   }
 }

--- a/swipe-pages.html
+++ b/swipe-pages.html
@@ -70,7 +70,7 @@ which is impossible given that the size of the `swipe-pages` element is well-def
 
     <link rel="stylesheet" href="swipe-pages.css" />
 
-    <div id="pagesContainer" class="pagesContainer" touch-action="pan-y">
+    <div id="pagesContainer" class="pagesContainer" touch-action="pan-y" layout horizontal>
       <content id="pages" select="swipe-page"></content>
     </div>
 
@@ -81,14 +81,6 @@ which is impossible given that the size of the `swipe-pages` element is well-def
     'use strict';
 
     var isWebkit = document.body.style.webkitTransform !== undefined;
-
-    var getPositionArray = function(length){
-      var a = [];
-      for (var i = 0; i < length; i++){
-        a[i] = (i * 100);
-      }
-      return a;
-    };
 
     var resetAnimations = function(element){
 
@@ -147,14 +139,6 @@ which is impossible given that the size of the `swipe-pages` element is well-def
       get pageWidth(){
         
         return this.getBoundingClientRect().width;
-      },
-
-      resetPositions : function(){
-        var positionArray = getPositionArray(this.pageCount);
-        for (var i = 0; i < this.pageCount; i++){
-          this.pages[i].style.left = ""  + (positionArray[i] / this.pageCount) + "%";
-          this.pages[i].style.top  = "-" + positionArray[i].toString() + "%";
-        }
       },
 
       resetWidths : function(){
@@ -264,7 +248,6 @@ which is impossible given that the size of the `swipe-pages` element is well-def
       },
 
       ready: function(){
-        this.resetPositions();
         this.resetWidths();
         this.setupEventHandlers();
       }


### PR DESCRIPTION
I had issues with the relative positioning system you were using, and found a much simpler method of achieving the same result: `[layout][horizontal]`. This allowed for removal of much of the related JS as well.
