### PR TITLE
Velocity swipe

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,9 +8,9 @@
   ],
   "main": "swipe-pages.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^0.4.0"
+    "polymer": "Polymer/polymer#0.5.4"
   },
   "devDependencies": {
-    "polymer-test-tools": "Polymer/polymer-test-tools#^0.4.0"
+    "polymer-test-tools": "Polymer/polymer-test-tools#0.5.4"
   }
 }

--- a/demo.html
+++ b/demo.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=no">
   <title>swipe-pages Demo</title>
 
-  <script src="../platform/platform.js"></script>
+  <script src="../webcomponentsjs/webcomponents.js"></script>
   <link rel="import" href="swipe-pages.html">
 
 </head>

--- a/demo.html
+++ b/demo.html
@@ -7,15 +7,32 @@
   <script src="../webcomponentsjs/webcomponents.js"></script>
   <link rel="import" href="swipe-pages.html">
 
+  <style>
+    body {
+      font-family: "Open Sans", sans-serif;
+    }
+    h1 {
+      font-size: 10em;
+      text-align: center;
+      color: white;
+    }
+  </style>
 </head>
 <body unresolved fullbleed layout vertical center center-justified>
   <swipe-pages>
-    <swipe-page style="background-color: blue" layout vertical>
+    <swipe-page style="background-color: #283593" layout vertical>
+      <h1>1</h1>
       <div style="top: 50%; height: 100%; width: 100%; background-color:beige"></div>
     </swipe-page>
-    <swipe-page style="background-color: red"></swipe-page>
-    <swipe-page style="background-color: green"></swipe-page>
-    <swipe-page style="background-color: indigo"></swipe-page>
+    <swipe-page style="background-color: #C62828">
+      <h1>2</h1>
+    </swipe-page>
+    <swipe-page style="background-color: #2E7D32">
+      <h1>3</h1>
+    </swipe-page>
+    <swipe-page style="background-color: #4A148C">
+      <h1>4</h1>
+    </swipe-page>
   </swipe-pages>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <script src="../platform/platform.js"></script>
+  <script src="../webcomponentsjs/webcomponents.js"></script>
   <link rel="import" href="../polymer/polymer.html">
   <link rel="import" href="../core-component-page/core-component-page.html">
 

--- a/swipe-pages.html
+++ b/swipe-pages.html
@@ -64,7 +64,7 @@ which is impossible given that the size of the `swipe-pages` element is well-def
 <link rel="import" href="swipe-page.html">
 
 
-<polymer-element name="swipe-pages" attributes="selected threshold transitionDuration">
+<polymer-element name="swipe-pages" attributes="selected threshold velocityThreshold transitionDuration">
 
   <template>
 
@@ -134,6 +134,14 @@ which is impossible given that the size of the `swipe-pages` element is well-def
 
     Polymer({
 
+      /*
+       * The timestamp of the trackStart event, used for calculating
+       * time difference and then velocity at trackEnd.
+       * Private property.
+       * @type Number
+       */
+      trackStartTime: 0,
+
       get pageCount(){
 
         return this.$.pages.getDistributedNodes().length;  
@@ -173,6 +181,7 @@ which is impossible given that the size of the `swipe-pages` element is well-def
 
       setupTrackStartEventHandler : function(){
         PolymerGestures.addEventListener(this, "trackstart", function(event){
+          this.trackStartTime = event.timeStamp;
           resetAnimations(this);
         });
       },
@@ -201,12 +210,15 @@ which is impossible given that the size of the `swipe-pages` element is well-def
         PolymerGestures.addEventListener(this, "trackend", function(event){
           var userIsSwipingLeftwards = (event.dx < 0);
           var userIsSwipingRightwards = (event.dx > 0);
+          var dt = event.timeStamp - this.trackStartTime;
+          var v = event.dx / dt;
 
           var thresholdWasCrossed = (Math.abs(event.dx) / this.pageWidth) > this.threshold;
+          var velocityThresholdWasCrossed = Math.abs(v) > this.velocityThreshold;
 
           setAnimationDuration(this.transitionDuration, this);
 
-          if (thresholdWasCrossed){
+          if (thresholdWasCrossed || velocityThresholdWasCrossed){
             if (userIsSwipingRightwards){
               this.selected = Math.max(this.selected - 1, 0);
             }
@@ -216,6 +228,9 @@ which is impossible given that the size of the `swipe-pages` element is well-def
           }else{
             moveToPage(this.selected, this);
           }
+
+          // reset trackStartTime value
+          this.trackStartTime = 0;
         });
       },
 
@@ -231,6 +246,17 @@ which is impossible given that the size of the `swipe-pages` element is well-def
           * @type Number
           */
         threshold: 0.3,
+
+        /**
+          * Specifies the velocity threshold the swipe has to pass to
+          * cause a page transition UNLESS the distance was enough.
+          * Expressed in px/ms (pixels per millisecond),
+          * positive numbers only.
+          * @attribute velocityThreshold
+          * @default 1.0
+          * @type Number
+          */
+        velocityThreshold: 1.0,
 
         /**
           * Specifies the duration (in seconds) of the transition from one

--- a/swipe-pages.html
+++ b/swipe-pages.html
@@ -219,15 +219,8 @@ which is impossible given that the size of the `swipe-pages` element is well-def
         });
       },
 
-      publish: {
 
-        /**
-          * Specifies the index of the currently selected page
-          * @attribute selected
-          * @default 0
-          * @type Number
-          */
-        threshold: 0.3,
+      publish: {
 
         /**
           * Specifies the threshold the user must swipe in order to
@@ -237,13 +230,21 @@ which is impossible given that the size of the `swipe-pages` element is well-def
           * @default 0.3
           * @type Number
           */
-        transitionDuration: 0.3,
+        threshold: 0.3,
 
         /**
           * Specifies the duration (in seconds) of the transition from one
           * page to another
           * @attribute transitionDuration
           * @default 0.3
+          * @type Number
+          */
+        transitionDuration: 0.3,
+
+        /**
+          * Specifies the index of the currently selected page
+          * @attribute selected
+          * @default 0
           * @type Number
           */
         selected: 0,


### PR DESCRIPTION
Solves issue: 
#4 Add an option to just swipe without crossing the threshold

Introduces a new attribute: `velocityThreshold`. By nature it should coexist with the current `threshold` attribute, though renaming it to for example `distanceThreshold` or `travelThreshold` should be considered.

Together with `threshold`, `velocityThreshold` makes the interaction feel much more natural. In particular, the user can perform quick "fling" or "flick" gesture to trigger the page switch, even if the gesture's `dx` does not pass the threshold. 

The most relevant commit is https://github.com/ohanhi/swipe-pages/commit/955c56af7584337adbf2e5cbcf8c63b1d06817ac , but I feel the others are important too.
